### PR TITLE
Fix calling validate_ussd_journey base command

### DIFF
--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -54,7 +54,7 @@ Setup
 
         .. code-block:: text
 
-            python validate_ussd_journey /file/path
+            python manage.py validate_ussd_journey /file/path
 
       To test the ussd view do this curl request.
 


### PR DESCRIPTION
The documentation on [setup](https://django-ussd-airflow.readthedocs.io/en/latest/quick_start.html#setup)  misses the `manage.py` file part on the ` validate your ussd screen file` section causing it to fail with the following error
> python: can't open file 'validate_ussd_journey': [Errno 2] No such file or directory.

Fixes it for _copy-paste_ squad 😊